### PR TITLE
Hide private API key from the source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 ### Project specific ###
 testFiles/*
+lib/api_keys.hpp
 
 ### C++ ###
 *.d

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include "lib/curl/curl.h"
 #include "lib/json.hpp"
+#include "lib/api_keys.hpp"
 #include <iostream>
 #include <fstream>
 #include <windows.h>
@@ -7,7 +8,6 @@
 using namespace std;
 using json = nlohmann::json;
 
-// API key: 6a23773c0153f0beac3cf62e6df26495
 // Compile: g++ main.cpp -o main.exe -lcurl
 
 // Global variables declaration
@@ -60,7 +60,7 @@ void urlConstruction()
 {
     // API-related variables declaration
     string url_base = "https://api.openweathermap.org/data/2.5/";
-    string url_appid = "&appid=6a23773c0153f0beac3cf62e6df26495";
+    string url_appid = "&appid=" + OPENWEATHERMAP_API_KEY;
     string url_mode;
     string url_consultType;
     string url_units;

--- a/menuSystem.cpp
+++ b/menuSystem.cpp
@@ -9,7 +9,6 @@
 using namespace std;
 using json = nlohmann::json;
 
-// API key: 6a23773c0153f0beac3cf62e6df26495
 // Compile: g++ menuSystem.cpp -o menuSystem.exe
 
 // Global variables declaration

--- a/weatherTest_lcurl.cpp
+++ b/weatherTest_lcurl.cpp
@@ -1,5 +1,6 @@
 #include "lib/curl/curl.h"
 #include "lib/json.hpp"
+#include "lib/api_keys.hpp"
 #include <iostream>
 #include <fstream>
 #include <windows.h>
@@ -7,7 +8,6 @@
 using namespace std;
 using json = nlohmann::json;
 
-// API key: 6a23773c0153f0beac3cf62e6df26495
 // Compile: g++ weatherTest_lcurl.cpp -o weatherTest_lcurl.exe -lcurl
 
 // Función que procesa cada chunk de datos recibido desde la API
@@ -33,7 +33,7 @@ int main()
 
     // Declaración de variables relacionadas con la API
     string base_url = "http://api.openweathermap.org/data/2.5/forecast?id=524901";
-    string apikey_url = "&appid=6a23773c0153f0beac3cf62e6df26495";
+    string apikey_url = "&appid=" + OPENWEATHERMAP_API_KEY;
     string units_url;
     string lang_url;
     int units;


### PR DESCRIPTION
## Move API key to a private header file
For security resasons, hardcoded [OpenWeatherMap API key](https://home.openweathermap.org/api_keys) has been removed from source files and replaced with usage of `OPENWEATHERMAP_API_KEY` from a new _lib/api_keys.hpp_ header. Updated _.gitignore_ to exclude the API key header from version control and improve security. The previous (leaked) API key, has been disabled from the service.

From now on, for the program to compile correctly, there must be a file named _api_keys.hpp_ inside the _lib/_ folder, with the following contents:

```c++
#ifndef OWM_API_KEY
#define OWM_API_KEY

const std::string OPENWEATHERMAP_API_KEY = "<your_api_key>";

#endif

``` 

Where `<your_api_key>` must be replaced with a personal API key obtained from a free or paid plan from the [OpenWeatherMap service](https://openweathermap.org/price).
